### PR TITLE
Removed usage of depricated code.

### DIFF
--- a/src/net/acomputerdog/OBFUtil/parse/types/CSVFileParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/CSVFileParser.java
@@ -2,7 +2,6 @@ package net.acomputerdog.OBFUtil.parse.types;
 
 import net.acomputerdog.OBFUtil.parse.FileParser;
 import net.acomputerdog.OBFUtil.table.OBFTable;
-import net.acomputerdog.core.file.TextFileReader;
 import net.acomputerdog.core.java.Patterns;
 
 import java.io.*;
@@ -10,6 +9,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
 
 /**
  * Reads and writes obfuscation mappings to a .csv file.  Due to variations in CSV formats, this class is abstract so that subclasses can identify the correct data to read.
@@ -46,47 +47,41 @@ public abstract class CSVFileParser implements FileParser {
         if (file == null) {
             throw new IllegalArgumentException("File must not be null!");
         }
-        TextFileReader reader = null;
-        try {
-            CSVFile csv = new CSVFile();
-            reader = new TextFileReader(file);
-            String[] lines = reader.readAllLines();
-            int lineNum = 0;
-            int realLineNum = 0;
-            String[] categories = new String[0];
-            for (String line : lines) {
-                if (!isLineEmpty(line)) {
-                    String[] items = line.split(Patterns.COMMA);
-                    if (lineNum == 0) {
-                        categories = items;
-                        lineNum = 0;
-                    } else {
-                        int itemNum = 0;
-                        for (String item : items) {
-                            if (itemNum < categories.length) {
-                                csv.addItem(categories[itemNum], item);
-                                itemNum++;
-                            } else {
-                                String newItem = csv.getItem(categories[itemNum - 1], csv.size() - 1) + "," + (item);
-                                csv.setItem(categories[itemNum - 1], csv.size() - 1, newItem);
-                            }
-                        }
-                        while (itemNum < categories.length) {
-                            csv.addItem(categories[itemNum], "");
+		
+        CSVFile csv = new CSVFile();
+        List<String> lines = FileUtils.readLines(file);
+        int lineNum = 0;
+        int realLineNum = 0;
+        String[] categories = new String[0];
+        for (String line : lines) {
+            if (!isLineEmpty(line)) {
+                String[] items = line.split(Patterns.COMMA);
+                if (lineNum == 0) {
+                    categories = items;
+                    lineNum = 0;
+                } else {
+                    int itemNum = 0;
+                    for (String item : items) {
+                        if (itemNum < categories.length) {
+                            csv.addItem(categories[itemNum], item);
                             itemNum++;
+                        } else {
+                            String newItem = csv.getItem(categories[itemNum - 1], csv.size() - 1) + "," + (item);
+                            csv.setItem(categories[itemNum - 1], csv.size() - 1, newItem);
                         }
-
                     }
-                    lineNum++;
+                    while (itemNum < categories.length) {
+                        csv.addItem(categories[itemNum], "");
+                        itemNum++;
+                    }
+
                 }
-                realLineNum++;
+                lineNum++;
             }
-            this.writeCSVToTable(file, csv, table);
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
+            realLineNum++;
         }
+        writeCSVToTable(file, csv, table);
+        
     }
 
     /**

--- a/src/net/acomputerdog/OBFUtil/parse/types/MCPCSVFileParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/MCPCSVFileParser.java
@@ -15,7 +15,7 @@ public class MCPCSVFileParser extends CSVFileParser {
     private static final int OBFNAME_INDEX = 0;
     private static final int DEOBFNAME_INDEX = 1;
     private static final int SIDE_INDEX = 2;
-    private static final int DESC_INDEX = 3;
+    //private static final int DESC_INDEX = 3;
 
     private final TargetType type;
     private final int side;

--- a/src/net/acomputerdog/OBFUtil/parse/types/OBFParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/OBFParser.java
@@ -5,12 +5,13 @@ import net.acomputerdog.OBFUtil.parse.FormatException;
 import net.acomputerdog.OBFUtil.parse.StreamParser;
 import net.acomputerdog.OBFUtil.table.OBFTable;
 import net.acomputerdog.OBFUtil.util.TargetType;
-import net.acomputerdog.core.file.TextFileReader;
 import net.acomputerdog.core.java.Patterns;
 
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.io.FileUtils;
 
 /**
  * Reads and write obfuscation mappings to a .obf file.
@@ -26,15 +27,7 @@ public class OBFParser implements FileParser, StreamParser {
         if (file == null) {
             throw new IllegalArgumentException("File must not be null!");
         }
-        TextFileReader reader = null;
-        try {
-            reader = new TextFileReader(file);
-            parseStringArray(reader.readAllLines(), table, overwrite);
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
-        }
+        parseStringList(FileUtils.readLines(file), table, overwrite);
     }
 
     @Override
@@ -73,7 +66,7 @@ public class OBFParser implements FileParser, StreamParser {
             while ((line = in.readLine()) != null) {
                 data.add(line);
             }
-            parseStringArray(data.toArray(new String[data.size()]), table, overwrite);
+            parseStringList(data, table, overwrite);
         } finally {
             if (in != null) {
                 in.close();
@@ -109,7 +102,7 @@ public class OBFParser implements FileParser, StreamParser {
         return (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("//"));
     }
 
-    private int parseStringArray(String[] lines, OBFTable table, boolean overwrite) throws FormatException {
+    private int parseStringList(List<String> lines, OBFTable table, boolean overwrite) throws FormatException {
         int line = 0;
         for (String str : lines) {
             line++;

--- a/src/net/acomputerdog/OBFUtil/util/TargetType.java
+++ b/src/net/acomputerdog/OBFUtil/util/TargetType.java
@@ -19,9 +19,13 @@ public enum TargetType {
     /**
      * A field
      */
-    FIELD("FIELD", "FD");
-    //TODO: Add comment and param?
-
+    FIELD("FIELD", "FD"),
+    //TO DO: Add comment and param?
+    /**
+     * A class constructor
+     */
+    CONSTRUCTOR("CONSTRUCTOR", "CSTR", "CS");
+    
     private final String[] aliases;
 
     TargetType(String... aliases) {
@@ -29,7 +33,7 @@ public enum TargetType {
     }
 
     /**
-     * Gets a TargetType from it's name or an aliase
+     * Gets a TargetType from it's name or an alias
      *
      * @param type The name to identify with
      * @return Return the TargetType identified by type


### PR DESCRIPTION
This has been bugging me to no end, since I use the source in my mcp setup rather than a precompiled binary.

There shouldn't be any major changes in behaviour.

Also I see TargetType.CONSTRUCTOR is marked as a new change. I thought it would've been put in long ago since it's used by Blazeloader but oh well.