### PR TITLE
Rewrote the Obf tables

### DIFF
--- a/src/net/acomputerdog/OBFUtil/parse/types/BLOBFParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/BLOBFParser.java
@@ -131,16 +131,16 @@ public class BLOBFParser implements FileParser, StreamParser {
                 if (parts.length < 7) {
                     throw new FormatException("Format error on line " + line + ": \"" + str + "\"");
                 }
-                if (overwrite || !table.hasTypeObf(parts[1], type)) {
+                if (overwrite || !table.hasObf(parts[1], type)) {
                     if (stripDescs) {
-                        table.addTypeSRG(type, parts[1], parts[3], parts[5]);
+                        table.addTypeSRG(parts[1], parts[3], parts[5], type);
                     } else {
-                        table.addTypeSRG(type, parts[1] + " " + parts[2], parts[3] + " " + parts[4], parts[5] + " " + parts[6]);
+                        table.addTypeSRG(parts[1] + " " + parts[2], parts[3] + " " + parts[4], parts[5] + " " + parts[6], type);
                     }
                 }
             } else {
-                if (overwrite || !table.hasTypeObf(parts[1], type)) {
-                    table.addTypeSRG(type, parts[1], parts[2], parts[3]);
+                if (overwrite || !table.hasObf(parts[1], type)) {
+                    table.addTypeSRG(parts[1], parts[2], parts[3], type);
                 }
             }
         }
@@ -165,11 +165,11 @@ public class BLOBFParser implements FileParser, StreamParser {
                 if (parts.length < 7) {
                     throw new FormatException("Format error on line " + line + ": \"" + str + "\"");
                 }
-                if (overwrite || !table.hasTypeObf(parts[1], type)) {
+                if (overwrite || !table.hasObf(parts[1], type)) {
                     table.addType(parts[1] + " " + parts[2], parts[5] + " " + parts[6], type);
                 }
             } else {
-                if (overwrite || !table.hasTypeObf(parts[1], type)) {
+                if (overwrite || !table.hasObf(parts[1], type)) {
                     table.addType(parts[1], parts[3], type);
                 }
             }
@@ -187,10 +187,10 @@ public class BLOBFParser implements FileParser, StreamParser {
     private void writeTableNormal(Writer out, OBFTable table) throws IOException {
 
         for (TargetType type : TargetType.values()) {
-            for (String obf : table.getAllTypeObf(type)) {
+            for (String obf : table.getAllObf(type)) {
                 out.write(type.name());
                 out.write(":");
-                String deobf = table.deobfType(obf, type);
+                String deobf = table.deobf(obf, type);
                 if (type == TargetType.METHOD) {
                     String[] obfParts = obf.split(Patterns.SPACE);
                     String obfName = obfParts[0];
@@ -219,11 +219,11 @@ public class BLOBFParser implements FileParser, StreamParser {
 
     private void writeTableSRG(Writer out, DirectOBFTableSRG table) throws IOException {
         for (TargetType type : TargetType.values()) {
-            for (String obf : table.getAllTypeObf(type)) {
+            for (String obf : table.getAllObf(type)) {
                 out.write(type.name());
                 out.write(":");
-                String srg = table.getSRGFromObfType(obf, type);
-                String deobf = table.deobfType(obf, type);
+                String srg = table.getSRGFromObf(obf, type);
+                String deobf = table.deobf(obf, type);
                 if (type == TargetType.METHOD) {
                     String[] obfParts = obf.split(Patterns.SPACE);
                     String obfName = obfParts[0];

--- a/src/net/acomputerdog/OBFUtil/parse/types/MCPCSVFileParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/MCPCSVFileParser.java
@@ -63,10 +63,10 @@ public class MCPCSVFileParser extends CSVFileParser {
     public CSVFile readCSVFromTable(File source, OBFTable table) {
         CSVFile csv = new CSVFile();
 
-        String[] obfs = table.getAllTypeObf(type);
+        String[] obfs = table.getAllObf(type);
         for (String obf : obfs) {
             csv.addItem("searge", obf);
-            csv.addItem("name", table.deobfType(obf, type));
+            csv.addItem("name", table.deobf(obf, type));
             csv.addItem("side", Integer.toString(ignoreSides ? 0 : side));
             csv.addItem("desc", "");
         }
@@ -92,23 +92,12 @@ public class MCPCSVFileParser extends CSVFileParser {
             e.printStackTrace();
             System.exit(-1);
         }
-        System.out.println("Packages:");
-        for (String str : table.getAllPackagesObf()) {
-            System.out.println("   " + str + " = " + table.deobfPackage(str));
+        for (TargetType i : TargetType.parsable()) {
+        	System.out.println(i.name() + ":");
+        	for (String str : table.getAllObf(i)) {
+                System.out.println("   " + str + " = " + table.deobf(str, i));
+            }
         }
-        System.out.println("Classes:");
-        for (String str : table.getAllClassesObf()) {
-            System.out.println("   " + str + " = " + table.deobfClass(str));
-        }
-        System.out.println("Fields:");
-        for (String str : table.getAllFieldsObf()) {
-            System.out.println("   " + str + " = " + table.deobfField(str));
-        }
-        System.out.println("Methods:");
-        for (String str : table.getAllMethodsObf()) {
-            System.out.println("   " + str + " = " + table.deobfMethod(str));
-        }
-
     }
 
     private static TargetType getTypeOfFile(File f) {

--- a/src/net/acomputerdog/OBFUtil/parse/types/OBFParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/OBFParser.java
@@ -121,7 +121,7 @@ public class OBFParser implements FileParser, StreamParser {
             if (obfParts.length < 2) {
                 throw new FormatException("Format error on line " + line + ": \"" + str + "\"");
             }
-            if (overwrite || !table.hasTypeDeobf(obfParts[0], type)) {
+            if (overwrite || !table.hasDeobf(obfParts[0], type)) {
                 table.addType(obfParts[0], obfParts[1], type);
             }
         }
@@ -130,8 +130,8 @@ public class OBFParser implements FileParser, StreamParser {
 
     private void writeTable(Writer out, OBFTable table) throws IOException {
         for (TargetType type : TargetType.values()) {
-            for (String obf : table.getAllTypeObf(type)) {
-                String deobf = table.deobfType(obf, type);
+            for (String obf : table.getAllObf(type)) {
+                String deobf = table.deobf(obf, type);
                 out.write(type.name());
                 out.write(":");
                 out.write(obf);

--- a/src/net/acomputerdog/OBFUtil/parse/types/SOBFFileParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/SOBFFileParser.java
@@ -67,7 +67,7 @@ public class SOBFFileParser implements FileParser {
             if (obfParts.length < 2) {
                 throw new FormatException("Format error on line " + line + ": \"" + str + "\"");
             }
-            if ((overwrite || !table.hasTypeDeobf(obfParts[0], type)) && (side == this.side)) {
+            if ((overwrite || !table.hasDeobf(obfParts[0], type)) && (side == this.side)) {
                 table.addType(obfParts[0], obfParts[1], type);
             }
         }
@@ -89,8 +89,8 @@ public class SOBFFileParser implements FileParser {
         try {
             out = new BufferedWriter(new FileWriter(file));
             for (TargetType type : TargetType.values()) {
-                for (String obf : table.getAllTypeObf(type)) {
-                    String deobf = table.deobfType(obf, type);
+                for (String obf : table.getAllObf(type)) {
+                    String deobf = table.deobf(obf, type);
                     out.write(type.name());
                     out.write(".");
                     out.write(this.side);

--- a/src/net/acomputerdog/OBFUtil/parse/types/SRGFileParser.java
+++ b/src/net/acomputerdog/OBFUtil/parse/types/SRGFileParser.java
@@ -76,7 +76,7 @@ public class SRGFileParser implements FileParser {
 
 
             }
-            if ((overwrite || !table.hasTypeDeobf(obf, type)) && (side.isEmpty() || side.equals(this.side))) {
+            if ((overwrite || !table.hasDeobf(obf, type)) && (side.isEmpty() || side.equals(this.side))) {
                 table.addType(obf, deobf, type);
             }
 
@@ -99,8 +99,8 @@ public class SRGFileParser implements FileParser {
         try {
             out = new BufferedWriter(new FileWriter(file));
             for (TargetType type : TargetType.values()) {
-                for (String obf : table.getAllTypeObf(type)) {
-                    String deobf = table.deobfType(obf, type);
+                for (String obf : table.getAllObf(type)) {
+                    String deobf = table.deobf(obf, type);
                     out.write(getPrefix(type));
                     out.write(": ");
                     out.write(obf);

--- a/src/net/acomputerdog/OBFUtil/table/DirectOBFTable.java
+++ b/src/net/acomputerdog/OBFUtil/table/DirectOBFTable.java
@@ -15,12 +15,10 @@ public class DirectOBFTable<P extends DirectOBFTable.ObfEntry, T extends ObfMap<
 	protected final TargetTypeMap<T> tableMappings = new TargetTypeMap<T>();
 	
     public String deobf(String obfName, TargetType type) {
-    	if (type == TargetType.CONSTRUCTOR) throw new IllegalArgumentException("Unknown target type: " + type.name());
 		return tableMappings.getChecked(type).byObf(obfName).deobfuscated;
     }
     
     public String obf(String deobfName, TargetType type) {
-    	if (type == TargetType.CONSTRUCTOR) throw new IllegalArgumentException("Unknown target type: " + type.name());
 		return tableMappings.getChecked(type).byDeobf(deobfName).obfuscated;
     }
         

--- a/src/net/acomputerdog/OBFUtil/table/DirectOBFTable.java
+++ b/src/net/acomputerdog/OBFUtil/table/DirectOBFTable.java
@@ -1,439 +1,119 @@
 package net.acomputerdog.OBFUtil.table;
 
+import net.acomputerdog.OBFUtil.util.ObfMap;
 import net.acomputerdog.OBFUtil.util.TargetType;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * A simple, direct implementation of OBFTable.  Uses HashMaps and ArrayLists to store data.
  */
-public class DirectOBFTable implements OBFTable {
-    private final Map<String, String> packageMapObf = new HashMap<String, String>();
-    private final List<String> packageListObf = new ArrayList<String>();
-    private final Map<String, String> classMapObf = new HashMap<String, String>();
-    private final List<String> classListObf = new ArrayList<String>();
-    private final Map<String, String> fieldMapObf = new HashMap<String, String>();
-    private final List<String> fieldListObf = new ArrayList<String>();
-    private final Map<String, String> methodMapObf = new HashMap<String, String>();
-    private final List<String> methodListObf = new ArrayList<String>();
-    private final Map<String, String> packageMapDeobf = new HashMap<String, String>();
-    private final List<String> packageListDeobf = new ArrayList<String>();
-    private final Map<String, String> classMapDeobf = new HashMap<String, String>();
-    private final List<String> classListDeobf = new ArrayList<String>();
-    private final Map<String, String> fieldMapDeobf = new HashMap<String, String>();
-    private final List<String> fieldListDeobf = new ArrayList<String>();
-    private final Map<String, String> methodMapDeobf = new HashMap<String, String>();
-    private final List<String> methodListDeobf = new ArrayList<String>();
-
-
-    public String deobfPackage(String obfName) {
-        return packageMapObf.get(obfName);
+public class DirectOBFTable<P extends DirectOBFTable.ObfEntry, T extends ObfMap<P>> implements OBFTable {
+	
+	protected final TargetTypeMap<T> tableMappings = new TargetTypeMap<T>();
+	
+    public String deobf(String obfName, TargetType type) {
+    	if (type == TargetType.CONSTRUCTOR) throw new IllegalArgumentException("Unknown target type: " + type.name());
+		return tableMappings.getChecked(type).byObf(obfName).deobfuscated;
     }
-
-    public String deobfClass(String obfName) {
-        return classMapObf.get(obfName);
+    
+    public String obf(String deobfName, TargetType type) {
+    	if (type == TargetType.CONSTRUCTOR) throw new IllegalArgumentException("Unknown target type: " + type.name());
+		return tableMappings.getChecked(type).byDeobf(deobfName).obfuscated;
     }
-
-    public String deobfField(String obfName) {
-        return fieldMapObf.get(obfName);
+        
+    public boolean hasObf(String obfName, TargetType type) {
+    	return tableMappings.getChecked(type).hasObf(obfName);
     }
-
-    public String deobfMethod(String obfName) {
-        return methodMapObf.get(obfName);
+    
+    public boolean hasDeobf(String deobfName, TargetType type) {
+    	return tableMappings.getChecked(type).hasDeObf(deobfName);
     }
-
-    @Override
-    public String deobfType(String obfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return deobfPackage(obfName);
-            }
-            case CLASS: {
-                return deobfClass(obfName);
-            }
-            case FIELD: {
-                return deobfField(obfName);
-            }
-            case METHOD: {
-                return deobfMethod(obfName);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
+    
+    public String[] getAllObf(TargetType type) {
+    	return tableMappings.getChecked(type).getAllObf();
     }
-
-    /**
-     * Gets the obfuscated name of a package.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    @Override
-    public String obfPackage(String deobfName) {
-        return packageMapDeobf.get(deobfName);
+    
+    public String[] getAllDeobf(TargetType type) {
+    	return tableMappings.getChecked(type).getAllDeObf();
     }
-
-    /**
-     * Gets the obfuscated name of a class.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    @Override
-    public String obfClass(String deobfName) {
-        return classMapDeobf.get(deobfName);
+    
+    protected void preAdd(TargetType type) {
+    	if (!tableMappings.containsKey(type)) tableMappings.put(type, createMap());
     }
-
-    /**
-     * Gets the obfuscated name of a field.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    @Override
-    public String obfField(String deobfName) {
-        return fieldMapDeobf.get(deobfName);
+    
+    protected T createMap() {
+    	return (T)new Mapping();
     }
-
-    /**
-     * Gets the obfuscated name of a method.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    @Override
-    public String obfMethod(String deobfName) {
-        return methodMapDeobf.get(deobfName);
-    }
-
-    /**
-     * Gets the obfuscated name of a TargetType.
-     *
-     * @param deobfName The deobfuscated name.
-     * @param type      The type of obfuscation to get.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    @Override
-    public String obfType(String deobfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return obfPackage(deobfName);
-            }
-            case CLASS: {
-                return obfClass(deobfName);
-            }
-            case FIELD: {
-                return obfField(deobfName);
-            }
-            case METHOD: {
-                return obfMethod(deobfName);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
-    }
-
-    public void addPackage(String obfName, String deObfName) {
-        packageMapObf.put(obfName, deObfName);
-        packageListObf.add(obfName);
-        packageMapDeobf.put(deObfName, obfName);
-        packageListDeobf.add(deObfName);
-    }
-
-    public void addClass(String obfName, String deObfName) {
-        classMapObf.put(obfName, deObfName);
-        classListObf.add(obfName);
-        classMapDeobf.put(deObfName, obfName);
-        classListDeobf.add(deObfName);
-    }
-
-    public void addField(String obfName, String deObfName) {
-        fieldMapObf.put(obfName, deObfName);
-        fieldListObf.add(obfName);
-        fieldMapDeobf.put(deObfName, obfName);
-        fieldListDeobf.add(deObfName);
-    }
-
-    public void addMethod(String obfName, String deObfName) {
-        methodMapObf.put(obfName, deObfName);
-        methodListObf.add(obfName);
-        methodMapDeobf.put(deObfName, obfName);
-        methodListDeobf.add(deObfName);
-    }
-
-    @Override
+    
     public void addType(String obfName, String deObfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                addPackage(obfName, deObfName);
-                break;
-            }
-            case CLASS: {
-                addClass(obfName, deObfName);
-                break;
-            }
-            case FIELD: {
-                addField(obfName, deObfName);
-                break;
-            }
-            case METHOD: {
-                addMethod(obfName, deObfName);
-                break;
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
+    	preAdd(type);
+    	tableMappings.get(type).add(obfName, deObfName);
     }
-
-    /**
-     * Checks if a package mapping is defined.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    @Override
-    public boolean hasPackageObf(String obfName) {
-        return packageListObf.contains(obfName);
-    }
-
-    /**
-     * Checks if a class mapping is defined.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    @Override
-    public boolean hasClassObf(String obfName) {
-        return classListObf.contains(obfName);
-    }
-
-    /**
-     * Checks if a field mapping is defined.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    @Override
-    public boolean hasFieldObf(String obfName) {
-        return fieldListObf.contains(obfName);
-    }
-
-    /**
-     * Checks if a method mapping is defined.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    @Override
-    public boolean hasMethodObf(String obfName) {
-        return methodListObf.contains(obfName);
-    }
-
-    /**
-     * Checks if a TargetType mapping is defined.
-     *
-     * @param obfName The obfuscated name.
-     * @param type    The type to check.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    @Override
-    public boolean hasTypeObf(String obfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return hasPackageObf(obfName);
-            }
-            case CLASS: {
-                return hasClassObf(obfName);
-            }
-            case FIELD: {
-                return hasFieldObf(obfName);
-            }
-            case METHOD: {
-                return hasMethodObf(obfName);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
-    }
-
-    @Override
-    public boolean hasPackageDeobf(String deobfName) {
-        return packageListDeobf.contains(deobfName);
-    }
-
-    @Override
-    public boolean hasClassDeobf(String deobfName) {
-        return classListDeobf.contains(deobfName);
-    }
-
-    @Override
-    public boolean hasFieldDeobf(String deobfName) {
-        return fieldListDeobf.contains(deobfName);
-    }
-
-    @Override
-    public boolean hasMethodDeobf(String deobfName) {
-        return methodListDeobf.contains(deobfName);
-    }
-
-    @Override
-    public boolean hasTypeDeobf(String deobfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return hasPackageDeobf(deobfName);
-            }
-            case CLASS: {
-                return hasClassDeobf(deobfName);
-            }
-            case FIELD: {
-                return hasFieldDeobf(deobfName);
-            }
-            case METHOD: {
-                return hasMethodDeobf(deobfName);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
-    }
-
-    @Override
-    public String[] getAllPackagesObf() {
-        return packageListObf.toArray(new String[packageListObf.size()]);
-    }
-
-    @Override
-    public String[] getAllClassesObf() {
-        return classListObf.toArray(new String[classListObf.size()]);
-    }
-
-    @Override
-    public String[] getAllFieldsObf() {
-        return fieldListObf.toArray(new String[fieldListObf.size()]);
-    }
-
-    @Override
-    public String[] getAllMethodsObf() {
-        return methodListObf.toArray(new String[methodListObf.size()]);
-    }
-
-    @Override
-    public String[] getAllTypeObf(TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getAllPackagesObf();
-            }
-            case CLASS: {
-                return getAllClassesObf();
-            }
-            case FIELD: {
-                return getAllFieldsObf();
-            }
-            case METHOD: {
-                return getAllMethodsObf();
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
-    }
-
-    /**
-     * Get an array of all deobfuscated package names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    @Override
-    public String[] getAllPackagesDeobf() {
-        return packageListDeobf.toArray(new String[packageListDeobf.size()]);
-    }
-
-    /**
-     * Get an array of all deobfuscated class names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    @Override
-    public String[] getAllClassesDeobf() {
-        return classListDeobf.toArray(new String[classListDeobf.size()]);
-    }
-
-    /**
-     * Get an array of all deobfuscated field names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    @Override
-    public String[] getAllFieldsDeobf() {
-        return fieldListDeobf.toArray(new String[fieldListDeobf.size()]);
-    }
-
-    /**
-     * Get an array of all deobfuscated method names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    @Override
-    public String[] getAllMethodsDeobf() {
-        return methodListDeobf.toArray(new String[methodListDeobf.size()]);
-    }
-
-    /**
-     * Get an array of all deobfuscated TargetType names.
-     *
-     * @param type The type to get.
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    @Override
-    public String[] getAllTypeDeobf(TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getAllPackagesDeobf();
-            }
-            case CLASS: {
-                return getAllClassesDeobf();
-            }
-            case FIELD: {
-                return getAllFieldsDeobf();
-            }
-            case METHOD: {
-                return getAllMethodsDeobf();
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown target type: " + type.name());
-            }
-        }
-    }
-
-    @Override
+    
     public void writeToTable(OBFTable table, boolean overwrite) {
-        for (String obfName : packageListObf) {
-            if (overwrite || !table.hasPackageObf(obfName)) {
-                table.addPackage(obfName, packageMapObf.get(obfName));
-            }
-        }
-        for (String obfName : classListObf) {
-            if (overwrite || !table.hasClassObf(obfName)) {
-                table.addClass(obfName, classMapObf.get(obfName));
-            }
-        }
-        for (String obfName : fieldListObf) {
-            if (overwrite || !table.hasFieldObf(obfName)) {
-                table.addField(obfName, fieldMapObf.get(obfName));
-            }
-        }
-        for (String obfName : methodListObf) {
-            if (overwrite || !table.hasMethodObf(obfName)) {
-                table.addMethod(obfName, methodMapObf.get(obfName));
-            }
-        }
+    	for (Entry<TargetType, T> i : tableMappings.entrySet()) {
+    		i.getValue().write(table, overwrite, i.getKey());
+    	}
     }
-
+    
+    protected class Mapping implements ObfMap<P> {
+    	
+    	private final Map<String, P> obfuscated = new HashMap<String, P>(); 
+    	private final Map<String, P> deobfuscated = new HashMap<String, P>();
+    	
+    	public String[] getAllObf() {
+    		return deobfuscated.keySet().toArray(new String[deobfuscated.size()]);
+    	}
+    	
+    	public String[] getAllDeObf() {
+    		return deobfuscated.keySet().toArray(new String[deobfuscated.size()]);
+    	}
+    	
+		public P byDeobf(String deobf) {
+			return deobfuscated.get(deobf);
+		}
+		
+		public P byObf(String obf) {
+			return obfuscated.get(obf);
+		}
+    	
+		public boolean hasObf(String obf) {
+			return obfuscated.containsKey(obf);
+		}
+		
+		public boolean hasDeObf(String deobf) {
+			return deobfuscated.containsKey(deobf);
+		}
+		
+		public void add(String obf, String deobf) {
+			add((P)new ObfEntry(obf, deobf));
+		}
+		
+		protected void add(P entry) {
+			obfuscated.put(entry.obfuscated, entry);
+			deobfuscated.put(entry.deobfuscated, entry);
+		}
+		
+		public void write(OBFTable table, boolean overwrite, TargetType type) {
+			for (Entry<String, P> i : obfuscated.entrySet()) {
+	            if (overwrite || !table.hasObf(i.getKey(), type)) {
+	            	table.addType(i.getKey(), i.getValue().deobfuscated, type);
+	            }
+	        }
+		}
+    }
+    
+    public class ObfEntry {
+		
+		public String obfuscated;
+		public String deobfuscated;
+		
+		public ObfEntry(String obf, String deobf) {
+			obfuscated = obf;
+			deobfuscated = deobf;
+		}
+	}
 }

--- a/src/net/acomputerdog/OBFUtil/table/DirectOBFTableSRG.java
+++ b/src/net/acomputerdog/OBFUtil/table/DirectOBFTableSRG.java
@@ -1,315 +1,85 @@
 package net.acomputerdog.OBFUtil.table;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import net.acomputerdog.OBFUtil.util.ObfMapSrg;
 import net.acomputerdog.OBFUtil.util.TargetType;
-import net.acomputerdog.core.storage.TripleStringMap;
 
 /**
  * OBFTable that adds support for a third "searge" obfuscation name.  Based on DirectOBFTable.
  */
-public class DirectOBFTableSRG extends DirectOBFTable implements OBFTableSRG {
-    private final TripleStringMap packages = new TripleStringMap();
-    private final TripleStringMap classes = new TripleStringMap();
-    private final TripleStringMap fields = new TripleStringMap();
-    private final TripleStringMap methods = new TripleStringMap();
-
-    @Override
-    public void addPackage(String obfName, String deObfName) {
-        addPackageSRG(obfName, deObfName, deObfName);
+public class DirectOBFTableSRG<P extends DirectOBFTableSRG.ObfEntrySrg, T extends ObfMapSrg<P>> extends DirectOBFTable<P, T> implements OBFTableSRG {
+	
+    public String getObfFromSRG(String searge, TargetType type) {
+    	return tableMappings.getChecked(type).bySrg(searge).obfuscated;
     }
-
-    @Override
-    public void addClass(String obfName, String deObfName) {
-        addClassSRG(obfName, deObfName, deObfName);
+    
+    public String getDeObfFromSRG(String searge, TargetType type) {
+    	return tableMappings.getChecked(type).bySrg(searge).deobfuscated;
     }
-
-    @Override
-    public void addField(String obfName, String deObfName) {
-        addFieldSRG(obfName, deObfName, deObfName);
+    
+    public String getSRGFromObf(String obf, TargetType type) {
+    	return tableMappings.getChecked(type).byObf(obf).searge;
     }
-
-    @Override
-    public void addMethod(String obfName, String deObfName) {
-        addMethodSRG(obfName, deObfName, deObfName);
+    
+    public String getSRGFromDeObf(String deobf, TargetType type) {
+    	return tableMappings.getChecked(type).byDeobf(deobf).searge;
     }
-
-    @Override
+    
+    public boolean hasSRG(String srgName, TargetType type) {
+    	return tableMappings.getChecked(type).hasSrg(srgName);
+    }
+    
+    protected T createMap() {
+    	return (T)new MappingSrg();
+    }
+    
     public void addType(String obfName, String deObfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                addPackage(obfName, deObfName);
-                break;
-            }
-            case CLASS: {
-                addClass(obfName, deObfName);
-                break;
-            }
-            case FIELD: {
-                addField(obfName, deObfName);
-                break;
-            }
-            case METHOD: {
-                addMethod(obfName, deObfName);
-                break;
-            }
-            default: {
-                super.addType(obfName, deObfName, type);
-                break;
-            }
-        }
+        addTypeSRG(obfName, deObfName, deObfName, type);
     }
-
-    public void addPackageSRG(String obfName, String seargeName, String deObfName) {
-        super.addPackage(obfName, deObfName);
-        packages.addItems(obfName, seargeName, deObfName);
-    }
-
-    public void addClassSRG(String obfName, String seargeName, String deObfName) {
-        super.addClass(obfName, deObfName);
-        classes.addItems(obfName, seargeName, deObfName);
-    }
-
-    public void addFieldSRG(String obfName, String seargeName, String deObfName) {
-        super.addField(obfName, deObfName);
-        fields.addItems(obfName, seargeName, deObfName);
-    }
-
-    public void addMethodSRG(String obfName, String seargeName, String deObfName) {
-        super.addMethod(obfName, deObfName);
-        methods.addItems(obfName, seargeName, deObfName);
-    }
-
-    @Override
+    
     public void addTypeSRG(String obfName, String seargeName, String deObfName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                addPackageSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case CLASS: {
-                addClassSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case FIELD: {
-                addFieldSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case METHOD: {
-                addMethodSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown TargetType!");
-            }
-        }
+    	preAdd(type);
+    	tableMappings.get(type).add(obfName, deObfName, seargeName);
     }
-
-
-    public String getObfFromSRGPackage(String searge) {
-        return packages.getFrom2(searge).getItem1();
+    
+    public class MappingSrg extends Mapping implements ObfMapSrg<P> {
+    	
+    	private final Map<String, P> searge = new HashMap<String, P>();
+    	
+		public String[] getAllSrg() {
+			return searge.keySet().toArray(new String[searge.size()]);
+		}
+		
+		public P bySrg(String srg) {
+			return searge.get(srg);
+		}
+		
+		public boolean hasSrg(String srg) {
+			return searge.containsKey(srg);
+		}
+		
+		public void add(String obf, String deobf, String srg) {
+			add((P)new ObfEntrySrg(obf, deobf, srg));
+		}
+		
+		public void add(String obf, String deobf) {
+			add(obf, deobf, deobf);
+		}
+    	
+		protected void add(P entry) {
+			super.add(entry);
+			searge.put(entry.searge, entry);
+		}
     }
-
-    public String getObfFromSRGClass(String searge) {
-        return classes.getFrom2(searge).getItem1();
-    }
-
-    public String getObfFromSRGField(String searge) {
-        return fields.getFrom2(searge).getItem1();
-    }
-
-    public String getObfFromSRGMethod(String searge) {
-        return methods.getFrom2(searge).getItem1();
-    }
-
-    public String getObfFromSRGType(String searge, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getObfFromSRGPackage(searge);
-            }
-            case CLASS: {
-                return getObfFromSRGClass(searge);
-            }
-            case FIELD: {
-                return getObfFromSRGField(searge);
-            }
-            case METHOD: {
-                return getObfFromSRGMethod(searge);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown TargetType!");
-            }
-        }
-    }
-
-    public String getDeObfFromSRGPackage(String searge) {
-        return packages.getFrom2(searge).getItem3();
-    }
-
-    public String getDeObfFromSRGClass(String searge) {
-        return classes.getFrom2(searge).getItem3();
-    }
-
-    public String getDeObfFromSRGField(String searge) {
-        return fields.getFrom2(searge).getItem3();
-    }
-
-    public String getDeObfFromSRGMethod(String searge) {
-        return methods.getFrom2(searge).getItem3();
-    }
-
-    public String getDeObfFromSRGType(String searge, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getDeObfFromSRGPackage(searge);
-            }
-            case CLASS: {
-                return getDeObfFromSRGClass(searge);
-            }
-            case FIELD: {
-                return getDeObfFromSRGField(searge);
-            }
-            case METHOD: {
-                return getDeObfFromSRGMethod(searge);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown TargetType!");
-            }
-        }
-    }
-
-    public String getSRGFromObfPackage(String obf) {
-        return packages.getFrom1(obf).getItem2();
-    }
-
-    public String getSRGFromObfClass(String obf) {
-        return classes.getFrom1(obf).getItem2();
-    }
-
-    public String getSRGFromObfField(String obf) {
-        return fields.getFrom1(obf).getItem2();
-    }
-
-    public String getSRGFromObfMethod(String obf) {
-        return methods.getFrom1(obf).getItem2();
-    }
-
-    public String getSRGFromObfType(String obf, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getSRGFromObfPackage(obf);
-            }
-            case CLASS: {
-                return getSRGFromObfClass(obf);
-            }
-            case FIELD: {
-                return getSRGFromObfField(obf);
-            }
-            case METHOD: {
-                return getSRGFromObfMethod(obf);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown TargetType!");
-            }
-        }
-    }
-
-    public String getSRGFromDeObfPackage(String deobf) {
-        return packages.getFrom3(deobf).getItem2();
-    }
-
-    public String getSRGFromDeObfClass(String deobf) {
-        return classes.getFrom3(deobf).getItem2();
-    }
-
-    public String getSRGFromDeObfField(String deobf) {
-        return fields.getFrom3(deobf).getItem2();
-    }
-
-    public String getSRGFromDeObfMethod(String deobf) {
-        return methods.getFrom3(deobf).getItem2();
-    }
-
-    public String getSRGFromDeObfType(String deobf, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return getSRGFromDeObfPackage(deobf);
-            }
-            case CLASS: {
-                return getSRGFromDeObfClass(deobf);
-            }
-            case FIELD: {
-                return getSRGFromDeObfField(deobf);
-            }
-            case METHOD: {
-                return getSRGFromDeObfMethod(deobf);
-            }
-            default: {
-                throw new IllegalArgumentException("Unknown TargetType!");
-            }
-        }
-    }
-
-    @Override
-    public boolean hasPackageSRG(String srgName) {
-        return packages.hasItem2(srgName);
-    }
-
-    @Override
-    public boolean hasClassSRG(String srgName) {
-        return classes.hasItem2(srgName);
-    }
-
-    @Override
-    public boolean hasMethodSRG(String srgName) {
-        return methods.hasItem2(srgName);
-    }
-
-    @Override
-    public boolean hasFieldSRG(String srgName) {
-        return fields.hasItem2(srgName);
-    }
-
-    @Override
-    public boolean hasTypeSRG(String srgName, TargetType type) {
-        switch (type) {
-            case PACKAGE: {
-                return hasPackageSRG(srgName);
-            }
-            case CLASS: {
-                return hasClassSRG(srgName);
-            }
-            case FIELD: {
-                return hasFieldSRG(srgName);
-            }
-            case METHOD: {
-                return hasMethodSRG(srgName);
-            }
-            default: {
-                throw new IllegalArgumentException("Invalid TargetType!");
-            }
-        }
-    }
-
-    public void addTypeSRG(TargetType type, String obfName, String seargeName, String deObfName) {
-        switch (type) {
-            case PACKAGE: {
-                addPackageSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case CLASS: {
-                addClassSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case FIELD: {
-                addFieldSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            case METHOD: {
-                addMethodSRG(obfName, seargeName, deObfName);
-                break;
-            }
-            default: {
-                throw new IllegalArgumentException("Invalid TargetType!");
-            }
-        }
-    }
+    
+    public class ObfEntrySrg extends DirectOBFTable.ObfEntry {
+		public String searge;
+		
+		public ObfEntrySrg(String obf, String deobf, String srg) {
+			super(obf, deobf);
+			searge = srg;
+		}
+	}
 }

--- a/src/net/acomputerdog/OBFUtil/table/OBFTable.java
+++ b/src/net/acomputerdog/OBFUtil/table/OBFTable.java
@@ -6,75 +6,14 @@ import net.acomputerdog.OBFUtil.util.TargetType;
  * Represents an object capable of managing obfuscation data.
  */
 public interface OBFTable {
-    /**
-     * Gets the deobfuscated name of a package.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return the deobfuscated name, or null if the mapping is not defined.
-     */
-    public String deobfPackage(String obfName);
-
-    /**
-     * Gets the deobfuscated name of a class.
-     *
-     * @param obfName The obfuscated name.
-     * @return Return the deobfuscated name, or null if the mapping is not defined.
-     */
-    public String deobfClass(String obfName);
-
-    /**
-     * Gets the deobfuscated name of a field.
-     * @param obfName The obfuscated name.
-     * @return Return the deobfuscated name, or null if the mapping is not defined.
-     */
-    public String deobfField(String obfName);
-
-    /**
-     * Gets the deobfuscated name of a method.
-     * @param obfName The obfuscated name.
-     * @return Return the deobfuscated name, or null if the mapping is not defined.
-     */
-    public String deobfMethod(String obfName);
-
+    
     /**
      * Gets the deobfuscated name of a TargetType.
      * @param obfName The obfuscated name.
      * @param type The type of obfuscation to get.
      * @return Return the deobfuscated name, or null if the mapping is not defined.
      */
-    public String deobfType(String obfName, TargetType type);
-
-    /**
-     * Gets the obfuscated name of a package.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    public String obfPackage(String deobfName);
-
-    /**
-     * Gets the obfuscated name of a class.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    public String obfClass(String deobfName);
-
-    /**
-     * Gets the obfuscated name of a field.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    public String obfField(String deobfName);
-
-    /**
-     * Gets the obfuscated name of a method.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return the obfuscated name, or null if the mapping is not defined.
-     */
-    public String obfMethod(String deobfName);
+    public String deobf(String obfName, TargetType type);
 
     /**
      * Gets the obfuscated name of a TargetType.
@@ -83,35 +22,7 @@ public interface OBFTable {
      * @param type      The type of obfuscation to get.
      * @return Return the obfuscated name, or null if the mapping is not defined.
      */
-    public String obfType(String deobfName, TargetType type);
-
-    /**
-     * Adds an obfuscation mapping for a package.
-     * @param obfName The obfuscated name.
-     * @param deObfName The deobfuscated name.
-     */
-    public void addPackage(String obfName, String deObfName);
-
-    /**
-     * Adds an obfuscation mapping for a class.
-     * @param obfName The obfuscated name.
-     * @param deObfName The deobfuscated name.
-     */
-    public void addClass(String obfName, String deObfName);
-
-    /**
-     * Adds an obfuscation mapping for a field.
-     * @param obfName The obfuscated name.
-     * @param deObfName The deobfuscated name.
-     */
-    public void addField(String obfName, String deObfName);
-
-    /**
-     * Adds an obfuscation mapping for a method.
-     * @param obfName The obfuscated name.
-     * @param deObfName The deobfuscated name.
-     */
-    public void addMethod(String obfName, String deObfName);
+    public String obf(String deobfName, TargetType type);
 
     /**
      * Adds an obfuscation mapping for a TargetType.
@@ -120,75 +31,15 @@ public interface OBFTable {
      * @param type The type to define.
      */
     public void addType(String obfName, String deObfName, TargetType type);
-
-    /**
-     * Checks if a package mapping is defined.
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasPackageObf(String obfName);
-
-    /**
-     * Checks if a class mapping is defined.
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasClassObf(String obfName);
-
-    /**
-     * Checks if a field mapping is defined.
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasFieldObf(String obfName);
-
-    /**
-     * Checks if a method mapping is defined.
-     * @param obfName The obfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasMethodObf(String obfName);
-
+    
     /**
      * Checks if a TargetType mapping is defined.
      * @param obfName The obfuscated name.
      * @param type The type to check.
      * @return Return true if the mapping is defined, false otherwise.
      */
-    public boolean hasTypeObf(String obfName, TargetType type);
-
-    /**
-     * Checks if a package mapping is defined.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasPackageDeobf(String deobfName);
-
-    /**
-     * Checks if a class mapping is defined.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasClassDeobf(String deobfName);
-
-    /**
-     * Checks if a field mapping is defined.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasFieldDeobf(String deobfName);
-
-    /**
-     * Checks if a method mapping is defined.
-     *
-     * @param deobfName The deobfuscated name.
-     * @return Return true if the mapping is defined, false otherwise.
-     */
-    public boolean hasMethodDeobf(String deobfName);
-
+    public boolean hasObf(String obfName, TargetType type);
+    
     /**
      * Checks if a TargetType mapping is defined.
      *
@@ -196,73 +47,22 @@ public interface OBFTable {
      * @param type      The type to check.
      * @return Return true if the mapping is defined, false otherwise.
      */
-    public boolean hasTypeDeobf(String deobfName, TargetType type);
-
-    /**
-     * Get an array of all obfuscated package names.
-     * @return Return an array of Strings representing all obfuscated names.
-     */
-    public String[] getAllPackagesObf();
-
-    /**
-     * Get an array of all obfuscated class names.
-     * @return Return an array of Strings representing all obfuscated names.
-     */
-    public String[] getAllClassesObf();
-
-    /**
-     * Get an array of all obfuscated field names.
-     * @return Return an array of Strings representing all obfuscated names.
-     */
-    public String[] getAllFieldsObf();
-
-    /**
-     * Get an array of all obfuscated method names.
-     * @return Return an array of Strings representing all obfuscated names.
-     */
-    public String[] getAllMethodsObf();
-
+    public boolean hasDeobf(String deobfName, TargetType type);
+    
     /**
      * Get an array of all obfuscated TargetType names.
      *
      * @param type The type to get.
      * @return Return an array of Strings representing all obfuscated names.
      */
-    public String[] getAllTypeObf(TargetType type);
-
-    /**
-     * Get an array of all deobfuscated package names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    public String[] getAllPackagesDeobf();
-
-    /**
-     * Get an array of all deobfuscated class names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    public String[] getAllClassesDeobf();
-
-    /**
-     * Get an array of all deobfuscated field names.
-     *
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    public String[] getAllFieldsDeobf();
-
-    /**
-     * Get an array of all deobfuscated method names.
-     * @return Return an array of Strings representing all deobfuscated names.
-     */
-    public String[] getAllMethodsDeobf();
-
+    public String[] getAllObf(TargetType type);
+    
     /**
      * Get an array of all deobfuscated TargetType names.
      * @param type The type to get.
      * @return Return an array of Strings representing all deobfuscated names.
      */
-    public String[] getAllTypeDeobf(TargetType type);
+    public String[] getAllDeobf(TargetType type);
 
     /**
      * Write the contents of this table to another table.

--- a/src/net/acomputerdog/OBFUtil/table/OBFTableSRG.java
+++ b/src/net/acomputerdog/OBFUtil/table/OBFTableSRG.java
@@ -6,63 +6,16 @@ import net.acomputerdog.OBFUtil.util.TargetType;
  * Extension to OBFTable that adds support for a third "searge" obfuscation name.
  */
 public interface OBFTableSRG extends OBFTable {
-    public void addPackageSRG(String obfName, String seargeName, String deObfName);
-
-    public void addClassSRG(String obfName, String seargeName, String deObfName);
-
-    public void addFieldSRG(String obfName, String seargeName, String deObfName);
-
-    public void addMethodSRG(String obfName, String seargeName, String deObfName);
-
+	
     public void addTypeSRG(String obfName, String seargeName, String deObfName, TargetType type);
-
-    public String getObfFromSRGPackage(String searge);
-
-    public String getObfFromSRGClass(String searge);
-
-    public String getObfFromSRGField(String searge);
-
-    public String getObfFromSRGMethod(String searge);
-
-    public String getObfFromSRGType(String searge, TargetType type);
-
-    public String getDeObfFromSRGPackage(String searge);
-
-    public String getDeObfFromSRGClass(String searge);
-
-    public String getDeObfFromSRGField(String searge);
-
-    public String getDeObfFromSRGMethod(String searge);
-
-    public String getDeObfFromSRGType(String searge, TargetType type);
-
-    public String getSRGFromObfPackage(String obf);
-
-    public String getSRGFromObfClass(String obf);
-
-    public String getSRGFromObfField(String obf);
-
-    public String getSRGFromObfMethod(String obf);
-
-    public String getSRGFromObfType(String obf, TargetType type);
-
-    public String getSRGFromDeObfPackage(String deobf);
-
-    public String getSRGFromDeObfClass(String deobf);
-
-    public String getSRGFromDeObfField(String deobf);
-
-    public String getSRGFromDeObfMethod(String deobf);
-
-    public String getSRGFromDeObfType(String deobf, TargetType type);
-
-    public boolean hasPackageSRG(String srgName);
-
-    public boolean hasClassSRG(String srgName);
-
-    public boolean hasMethodSRG(String srgName);
-
-    public boolean hasFieldSRG(String srgName);
-
-    public boolean hasTypeSRG(String srgName, TargetType type);
+    
+    public String getObfFromSRG(String searge, TargetType type);
+    
+    public String getDeObfFromSRG(String searge, TargetType type);
+    
+    public String getSRGFromObf(String obf, TargetType type);
+    
+    public String getSRGFromDeObf(String deobf, TargetType type);
+    
+    public boolean hasSRG(String srgName, TargetType type);
 }

--- a/src/net/acomputerdog/OBFUtil/table/TargetTypeMap.java
+++ b/src/net/acomputerdog/OBFUtil/table/TargetTypeMap.java
@@ -1,0 +1,13 @@
+package net.acomputerdog.OBFUtil.table;
+
+import java.util.HashMap;
+
+import net.acomputerdog.OBFUtil.util.TargetType;
+
+public class TargetTypeMap<T> extends HashMap<TargetType, T> {
+	
+	public T getChecked(TargetType type) {
+		if (!containsKey(type)) throw new IllegalArgumentException("Unknown target type: " + type.name());
+		return get(type);
+	}
+}

--- a/src/net/acomputerdog/OBFUtil/tool/BLConfigGen.java
+++ b/src/net/acomputerdog/OBFUtil/tool/BLConfigGen.java
@@ -49,15 +49,14 @@ public class BLConfigGen {
     }
 
     private static void addSRGsMethod(DirectOBFTableSRG dest, OBFTable sourceSRG, OBFTable sourceMCP) {
-
-        for (String str : sourceSRG.getAllMethodsDeobf()) {
+        for (String str : sourceSRG.getAllDeobf(TargetType.METHOD)) {
             String[] parts1 = str.split(Patterns.SPACE);
             if (parts1.length >= 1) {
                 String[] parts2 = parts1[0].split(Patterns.PERIOD);
-                String obf = sourceSRG.obfMethod(str);
+                String obf = sourceSRG.obf(str, TargetType.METHOD);
                 String searge = parts2[parts2.length - 1];
-                String mcp = sourceMCP.deobfMethod(searge);
-                dest.addMethodSRG(obf, str, rebuildName(parts2, mcp) + " " + parts1[1]);
+                String mcp = sourceMCP.deobf(searge, TargetType.METHOD);
+                dest.addTypeSRG(obf, str, rebuildName(parts2, mcp) + " " + parts1[1], TargetType.METHOD);
             } else {
                 System.out.println("No parts: " + str);
             }
@@ -65,27 +64,27 @@ public class BLConfigGen {
     }
 
     private static void addSRGsField(DirectOBFTableSRG dest, OBFTable sourceSRG, OBFTable sourceMCP) {
-        for (String str : sourceSRG.getAllFieldsDeobf()) {
+        for (String str : sourceSRG.getAllDeobf(TargetType.FIELD)) {
             String[] parts = str.split(Patterns.PERIOD);
             if (parts.length >= 1) {
                 String searge = parts[parts.length - 1];
-                String mcp = sourceMCP.deobfField(searge);
-                String obf = sourceSRG.obfField(str);
-                dest.addFieldSRG(obf, str, rebuildName(parts, mcp));
+                String mcp = sourceMCP.deobf(searge, TargetType.FIELD);
+                String obf = sourceSRG.obf(str, TargetType.FIELD);
+                dest.addTypeSRG(obf, str, rebuildName(parts, mcp), TargetType.FIELD);
             } else {
                 System.out.println("No parts: " + str);
             }
         }
     }
-
+    
     private static void addOthers(OBFTable dest, OBFTable source) {
-        for (String str : source.getAllClassesObf()) {
-            String cls = source.deobfClass(str);
-            dest.addClass(str, cls);
+        for (String str : source.getAllObf(TargetType.CLASS)) {
+            String cls = source.deobf(str, TargetType.CLASS);
+            dest.addType(str, cls, TargetType.CLASS);
         }
-        for (String str : source.getAllPackagesObf()) {
-            String pkg = source.deobfPackage(str);
-            dest.addPackage(str, pkg);
+        for (String str : source.getAllObf(TargetType.PACKAGE)) {
+            String pkg = source.deobf(str, TargetType.PACKAGE);
+            dest.addType(str, pkg, TargetType.PACKAGE);
         }
     }
 

--- a/src/net/acomputerdog/OBFUtil/util/ObfMap.java
+++ b/src/net/acomputerdog/OBFUtil/util/ObfMap.java
@@ -1,0 +1,22 @@
+package net.acomputerdog.OBFUtil.util;
+
+import net.acomputerdog.OBFUtil.table.OBFTable;
+
+public interface ObfMap<T> {
+	
+	public String[] getAllObf();
+	
+	public String[] getAllDeObf();
+	
+	public T byDeobf(String deobf);
+	
+	public T byObf(String obf);
+	
+	public boolean hasObf(String obf);
+	
+	public boolean hasDeObf(String deobf);
+	
+	public void add(String obf, String deobf);
+	
+	public void write(OBFTable table, boolean overwrite, TargetType type);
+}

--- a/src/net/acomputerdog/OBFUtil/util/ObfMapSrg.java
+++ b/src/net/acomputerdog/OBFUtil/util/ObfMapSrg.java
@@ -1,0 +1,12 @@
+package net.acomputerdog.OBFUtil.util;
+
+public interface ObfMapSrg<T> extends ObfMap<T> {
+	
+	public String[] getAllSrg();
+	
+	public T bySrg(String srg);
+	
+	public boolean hasSrg(String srg);
+	
+	public void add(String obf, String deobf, String srg);
+}

--- a/src/net/acomputerdog/OBFUtil/util/TargetType.java
+++ b/src/net/acomputerdog/OBFUtil/util/TargetType.java
@@ -1,5 +1,7 @@
 package net.acomputerdog.OBFUtil.util;
 
+import java.util.ArrayList;
+
 /**
  * Represents the part of a class to target.
  */
@@ -50,5 +52,21 @@ public enum TargetType {
             }
         }
         return null;
+    }
+    
+    private static TargetType[] parsable;
+    
+    public static TargetType[] parsable() {
+    	return parsable;
+    }
+    
+    static {
+    	ArrayList<TargetType> temp = new ArrayList();
+    	for (TargetType i : values()) {
+    		if (i != CONSTRUCTOR) {
+    			temp.add(i);
+    		}
+    	}
+    	parsable = temp.toArray(new TargetType[temp.size()]);
     }
 }


### PR DESCRIPTION
Been wanting to do this for a while. I cleaned out a lot of stuff and they should now read a lot better.

All of the specialised methods are now gone in favour of their more general variants. There's no more need for switch statements, and documentation is no longer duplicated across implementations.

The srg table now makes full use of its inherited class, just adding a searge field to its entries and required components for doing a lookup for/with searge values.